### PR TITLE
[FLY-836] Python 2 and 3 compatibility

### DIFF
--- a/pyzipcode/__init__.py
+++ b/pyzipcode/__init__.py
@@ -1,13 +1,11 @@
 """The pyzipcode package"""
 
-
-from pyzipcode.settings import db_location
-try:
-    import sqlite3
-except ImportError:
-    from pysqlite2 import dbapi2 as sqlite3
+from __future__ import absolute_import, division, unicode_literals
 
 import time
+import sqlite3
+
+from pyzipcode.settings import db_location
 
 
 class ConnectionManager(object):
@@ -100,6 +98,7 @@ class ZipNotFoundException(Exception):
     Exception that is raised when a zipcode is not found in the database
     """
     pass
+
 
 class ZipCodeDatabase(object):
     """

--- a/pyzipcode/import_zipcodes.py
+++ b/pyzipcode/import_zipcodes.py
@@ -16,17 +16,12 @@ Example usage::
 
 """
 
-try:
-    import sqlite3
-except ImportError:
-    from pysqlite2 import dbapi2 as sqlite3
+from __future__ import absolute_import, unicode_literals
 
-import os
 import csv
-try:
-    from settings import db_location, csv_location
-except:
-    from pyzipcode.settings import db_location, csv_location
+import sqlite3
+
+from pyzipcode.settings import db_location, csv_location
 
 
 def run_import():
@@ -46,7 +41,7 @@ def run_import():
     c.execute("CREATE INDEX state_index ON ZipCodes(state);")
 
     reader = csv.reader(open(csv_location, "rb"))
-    reader.next() # prime it
+    reader.next()  # prime it
 
     for row in reader:
         zip, city, state, lat, longt, timezone, dst = row
@@ -60,7 +55,7 @@ def run_import():
                 float(lat),
                 timezone,
                 dst
-        ))
+            ))
 
     conn.commit()
 

--- a/pyzipcode/settings.py
+++ b/pyzipcode/settings.py
@@ -2,8 +2,10 @@
 Settings common throughout the pyzipcode package.
 """
 
+from __future__ import absolute_import, unicode_literals
 
 import os
+
 
 # The name of the SQLite database file
 db_filename = 'zipcodes.db'

--- a/pyzipcode/tests.py
+++ b/pyzipcode/tests.py
@@ -1,5 +1,5 @@
-
 import unittest
+
 import pyzipcode
 
 
@@ -10,38 +10,38 @@ class TestSequenceFunctions(unittest.TestCase):
 
     def test_retrieves_zip_code_information(self):
         zip = self.db['54115']
-        self.assertEquals(zip.zip, '54115')
-        self.assertEquals(zip.city, "De Pere")
-        self.assertEquals(zip.state, "WI")
-        
+        self.assertEqual(zip.zip, '54115')
+        self.assertEqual(zip.city, "De Pere")
+        self.assertEqual(zip.state, "WI")
+
     def test_correct_longitude_value(self):
         zip = self.db[54115]
         self.assertTrue(zip.latitude > 44.42041 and zip.latitude < 44.42043)
-    
+
     def test_correct_latitude_value(self):
         zip = self.db[54115]
         self.assertTrue(zip.longitude > -88.07897 and zip.longitude < -88.07895)
-        
+
     def test_correct_timezone(self):
         zip = self.db[54115]
-        self.assertEquals(zip.timezone, -6)
-        
+        self.assertEqual(zip.timezone, -6)
+
     def test_correct_dst(self):
         zip = self.db[54115]
-        self.assertEquals(zip.dst, 1)
-        
+        self.assertEqual(zip.dst, 1)
+
     def test_radius(self):
         zips = self.db.get_zipcodes_around_radius('54115', 30)
         self.assertTrue('54304' in [zip.zip for zip in zips])
-        
+
     def test_find_zip_by_city(self):
         zip = self.db.find_zip(city="De Pere")[0]
-        self.assertEquals('54115', zip.zip)
-        
+        self.assertEqual('54115', zip.zip)
+
     def test_find_zip_by_city_with_multiple_zips(self):
         zips = self.db.find_zip(city="Green Bay")
         self.assertTrue('54302' in [zip.zip for zip in zips])
-        
+
     def test_find_zips_in_state(self):
         zips = self.db.find_zip(state="WI")
         self.assertTrue('54304' in [zip.zip for zip in zips])

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,12 @@
 from setuptools import setup, find_packages
-import sys, os
 
-version = '1.0'
+version = '1.1'
 
 setup(name='pyzipcode',
       version=version,
       description="query zip codes and location data",
       long_description=open("README.txt").read() + '\n\n' + open('CHANGES.txt').read(),
-      classifiers=[], # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
+      classifiers=[],  # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
       keywords='zip code distance',
       author='Nathan Van Gheem',
       author_email='vangheem@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(name='pyzipcode',
       install_requires=[
         'pysqlite'
       ],
+      python_requires='>=2.6, !=3.0.*, !=3.1.*, !=3.2.*, <4',
       entry_points="""
       # -*- Entry points: -*-
       """,


### PR DESCRIPTION
# Ticket

[FLY-836: Upgrade pyzipcode to be compatible with Python 2 and 3](https://styleseat.atlassian.net/browse/FLY-836)

## Related PRs

https://github.com/styleseat/styleseat/pull/5672

## Description

Enable compatibility for both Python 2 and 3.

I also looked at other up-to-date [forks](https://github.com/fdintino/pyzipcode/network/members) of [upstream](https://github.com/fdintino/pyzipcode) with Python 3 support, but there wasn't an obvious one to go with.

I also looked at [pyzipcode3](https://github.com/dvf/pyzipcode3), which was a great candidate, but the internals change the field from `city` to `place` which would require additional code change in the usages of pyzipcode. We can probably switch to this one eventually though in future "cleanup" effort.

#### Breaking changes
- Drop Python 2.4 and below

#### Compatibility fixes
- Always use absolute imports
- Always use unicode literals
- Use proper division -- note that dividing by a float forced this effect in Python 2, though I'll leave this code alone so no core logic is touched in this PR
- Always use `sqlite3` since it was added to Python in 2.5
- Update tests to use `assertEqual` since `assertEquals` is deprecated
- Small linting tweaks
